### PR TITLE
fix: cancel order err

### DIFF
--- a/pkg/model/market/subscribemarketbypriceresponse.go
+++ b/pkg/model/market/subscribemarketbypriceresponse.go
@@ -1,12 +1,17 @@
 package market
 
 import (
-	"github.com/huobirdcenter/huobi_golang/pkg/model/base"
 	"github.com/shopspring/decimal"
+
+	"github.com/huobirdcenter/huobi_golang/pkg/model/base"
 )
 
 type SubscribeMarketByPriceResponse struct {
 	base.WebSocketResponseBase
+
+	// for full req
+	Rep string `json:"rep"`
+
 	Tick *MarketByPrice
 	Data *MarketByPrice
 }

--- a/pkg/model/order/cancelorderbyidresponse.go
+++ b/pkg/model/order/cancelorderbyidresponse.go
@@ -5,5 +5,5 @@ type CancelOrderByIdResponse struct {
 	Data         string `json:"data"`
 	ErrorCode    string `json:"err-code"`
 	ErrorMessage string `json:"err-msg"`
-	OrderState   string `json:"order-state"`
+	OrderState   int    `json:"order-state"`
 }


### PR DESCRIPTION
json: cannot unmarshal number into Go struct field CancelOrderByIdResponse.order-state of type string