### PR TITLE
Fix cancelorderbyidresponse marshalling error (issue 51)

### DIFF
--- a/pkg/model/order/cancelorderbyidresponse.go
+++ b/pkg/model/order/cancelorderbyidresponse.go
@@ -5,5 +5,5 @@ type CancelOrderByIdResponse struct {
 	Data         string `json:"data"`
 	ErrorCode    string `json:"err-code"`
 	ErrorMessage string `json:"err-msg"`
-	OrderState   string `json:"order-state"`
+	OrderState   int    `json:"order-state"`
 }


### PR DESCRIPTION
Fixing the [issue 51](https://github.com/HuobiRDCenter/huobi_Golang/issues/51) due to type mismatch between Huobi response (which is numeric) and `CancelOrderByIdResponse.OrderState`, which is string.

